### PR TITLE
Forcing js requirements placement

### DIFF
--- a/mysite/code/Page.php
+++ b/mysite/code/Page.php
@@ -39,6 +39,7 @@ class Page_Controller extends ContentController {
 			)
 		);
 		
+		Requirements::set_force_js_to_bottom(true);
 		// Requirements::customScript();
 
 	}


### PR DESCRIPTION
Forcing js requirements to render at the bottom of the the body so that they don't interfer with any scripts added via the ss template eg tag manager
